### PR TITLE
jQueryのバージョンを更新

### DIFF
--- a/benchmarkserver/html/index.html
+++ b/benchmarkserver/html/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <title>実験A Webシステム高速化スコアサーバ</title>
   <link rel="stylesheet" href="../css/index.css">
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script type="text/javascript" src="../script/index.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <script src="../script/index.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
jQuery 3 より前のバージョンは更新が終了しているため、現在の最新版に更新しました。

ついでに、`<script>`の`type`を消しました。  
([HTML5のspec](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type)では必要のない限り`type`属性を記述しないことが推奨されている)